### PR TITLE
WIP: Twitch followers

### DIFF
--- a/bin/borkedbot.sh
+++ b/bin/borkedbot.sh
@@ -95,7 +95,18 @@ case "$1" in
         cd ${TOOL_DIR}
         exec python -m borked_bot.ballotpedia_page
         ;;
-
+    run-twitch)
+        date +%Y-%m-%dT%H:%M:%S
+        echo "Running borkedbot twitch filler..."
+        cd ${TOOL_DIR}
+        exec python -m borked_bot.twitch_chan_fill
+        ;;
+    run-twitch-fol)
+        date +%Y-%m-%dT%H:%M:%S
+        echo "Running borkedbot twitch follows filler..."
+        cd ${TOOL_DIR}
+        exec python -m borked_bot.twitch_follows
+        ;;
     stop)
         echo "Stopping borkedbot k8s job..."
         $KUBECTL delete job ${DEPLOYMENT}

--- a/borked_bot/util/twitch.py
+++ b/borked_bot/util/twitch.py
@@ -1,67 +1,20 @@
 from ..credentials import CREDENTIALS
-from .util import *
-from requests.exceptions import ReadTimeout, ConnectionError
-
-MAX_RESULTS = 100
+from twitchAPI.twitch import Twitch
 
 
-class TwitchError(Exception): pass
+async def make_twitch_client():
+    return await Twitch(CREDENTIALS["twitch-client-id"], CREDENTIALS["twitch-secret"])
 
 
-@retry(exceptions=[ConnectionError, ReadTimeout])
-def get_twitch_access_token(session):
-    # https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#client-credentials-grant-flow
-    params = {
-        "client_id": CREDENTIALS["twitch-client-id"],
-        "client_secret": CREDENTIALS["twitch-secret"],
-        "grant_type": "client_credentials",
-    }
-    r = session.post("https://id.twitch.tv/oauth2/token", data=params)
-    r.raise_for_status()
-    data = r.json()
-    # The response also includes an "expires_in" field, which is the number of seconds
-    # the token is valid for. Technically we get penalized if we are frequently calling
-    # the API with expired tokens. But from my testing these tokens are good for multiple
-    # days at a time, so I won't implement that now.
-    return data["access_token"]
-
-
-@retry(exceptions=[ConnectionError, ReadTimeout])
-def create_twitch_session():
-    s = get_session()
-    s.headers.update({
-        "Client-Id": CREDENTIALS["twitch-client-id"],
-    })
-    token = get_twitch_access_token(s)
-    s.headers.update({
-        "Client-Id": CREDENTIALS["twitch-client-id"],
-        "Authorization": f"Bearer {token}",
-    })
-    return s
-
-
-@retry(exceptions=[ConnectionError, ReadTimeout])
-def batch_get_twitch_ids(session, handles):
-    if len(handles) > MAX_RESULTS:
-        raise TwitchError(f"Cannot lookup more than {MAX_RESULTS} handles")
-    params = {
-        "login": handles, # login=foo&login=bar&login=baz
-    }
-    r = session.get("https://api.twitch.tv/helix/users", params=params)
-    r.raise_for_status()
-    data = r.json()
+async def batch_get_twitch_ids(twitch, handles):
+    # There is a limit of 100 users at one time. I'm assuming the client will give a
+    # good descriptive exception when we exceed that, otherwise we should add a check.
+    users = twitch.get_users(logins=handles)
     return {
-        user["login"]: user["id"]
-        for user in data
+        user.login: user.id
+        async for user in users
     }
 
-
-@retry(exceptions=[ConnectionError, ReadTimeout])
-def get_twitch_follows(session, user_id):
-    params = {
-        "broadcaster_id": user_id,
-    }
-    r = session.get("https://api.twitch.tv/helix/channels/followers", params=params)
-    r.raise_for_status()
-    data = r.json()
-    return data["total"]
+async def get_twitch_follows(twitch, numeric_user_id):
+    r = await twitch.get_channel_followers(numeric_user_id)
+    return r.total

--- a/borked_bot/util/twitch.py
+++ b/borked_bot/util/twitch.py
@@ -1,0 +1,67 @@
+from ..credentials import CREDENTIALS
+from .util import *
+from requests.exceptions import ReadTimeout, ConnectionError
+
+MAX_RESULTS = 100
+
+
+class TwitchError(Exception): pass
+
+
+@retry(exceptions=[ConnectionError, ReadTimeout])
+def get_twitch_access_token(session):
+    # https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#client-credentials-grant-flow
+    params = {
+        "client_id": CREDENTIALS["twitch-client-id"],
+        "client_secret": CREDENTIALS["twitch-secret"],
+        "grant_type": "client_credentials",
+    }
+    r = session.post("https://id.twitch.tv/oauth2/token", data=params)
+    r.raise_for_status()
+    data = r.json()
+    # The response also includes an "expires_in" field, which is the number of seconds
+    # the token is valid for. Technically we get penalized if we are frequently calling
+    # the API with expired tokens. But from my testing these tokens are good for multiple
+    # days at a time, so I won't implement that now.
+    return data["access_token"]
+
+
+@retry(exceptions=[ConnectionError, ReadTimeout])
+def create_twitch_session():
+    s = get_session()
+    s.headers.update({
+        "Client-Id": CREDENTIALS["twitch-client-id"],
+    })
+    token = get_twitch_access_token(s)
+    s.headers.update({
+        "Client-Id": CREDENTIALS["twitch-client-id"],
+        "Authorization": f"Bearer {token}",
+    })
+    return s
+
+
+@retry(exceptions=[ConnectionError, ReadTimeout])
+def batch_get_twitch_ids(session, handles):
+    if len(handles) > MAX_RESULTS:
+        raise TwitchError(f"Cannot lookup more than {MAX_RESULTS} handles")
+    params = {
+        "login": handles, # login=foo&login=bar&login=baz
+    }
+    r = session.get("https://api.twitch.tv/helix/users", params=params)
+    r.raise_for_status()
+    data = r.json()
+    return {
+        user["login"]: user["id"]
+        for user in data
+    }
+
+
+@retry(exceptions=[ConnectionError, ReadTimeout])
+def get_twitch_follows(session, user_id):
+    params = {
+        "broadcaster_id": user_id,
+    }
+    r = session.get("https://api.twitch.tv/helix/channels/followers", params=params)
+    r.raise_for_status()
+    data = r.json()
+    return data["total"]

--- a/etc/twit-cron.yaml
+++ b/etc/twit-cron.yaml
@@ -18,7 +18,7 @@ spec:
       template:
         metadata:
           labels:
-            name: borkedbot.bot-twitch
+            name: borkedbot.bot-twit
             toolforge: tool
         spec:
           activeDeadlineSeconds: 604800

--- a/etc/twitch-cron.yaml
+++ b/etc/twitch-cron.yaml
@@ -3,13 +3,13 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: borkedbot.bot-twit
+  name: borkedbot.bot-twitch
   namespace: tool-borkedbot
   labels:
-    name: borkedbot.bot-twit
+    name: borkedbot.bot-twitch
     toolforge: tool
 spec:
-  schedule: "0 0 * * 1" # weekly on monday
+  schedule: "@weekly"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
@@ -26,7 +26,7 @@ spec:
           containers:
             - name: bot
               image: docker-registry.tools.wmflabs.org/toolforge-python37-sssd-base:latest
-              command: [ "/data/project/borkedbot/borked-bot/bin/borkedbot.sh", "run-twt" ]
+              command: [ "/data/project/borkedbot/borked-bot/bin/borkedbot.sh", "run-twitch" ]
               workingDir: /data/project/borkedbot
               env:
                 - name: HOME

--- a/etc/twitch-fol-cron.yaml
+++ b/etc/twitch-fol-cron.yaml
@@ -3,33 +3,32 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: borkedbot.bot-twit
+  name: borkedbot.bot-twitch-fol
   namespace: tool-borkedbot
   labels:
-    name: borkedbot.bot-twit
+    name: borkedbot.bot-twitch-fol
     toolforge: tool
 spec:
-  schedule: "0 0 * * 1" # weekly on monday
+  schedule: "@weekly"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
-  failedJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1  
   jobTemplate:
     spec:
       template:
         metadata:
           labels:
-            name: borkedbot.bot-twitch
+            name: borkedbot.bot-twitch-fol
             toolforge: tool
         spec:
           activeDeadlineSeconds: 604800
-          restartPolicy: OnFailure      
+          restartPolicy: OnFailure
           containers:
             - name: bot
               image: docker-registry.tools.wmflabs.org/toolforge-python37-sssd-base:latest
-              command: [ "/data/project/borkedbot/borked-bot/bin/borkedbot.sh", "run-twt" ]
+              command: [ "/data/project/borkedbot/borked-bot/bin/borkedbot.sh", "run-twitch-fol" ]
               workingDir: /data/project/borkedbot
               env:
                 - name: HOME
                   value: /data/project/borkedbot
               imagePullPolicy: Always
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ six==1.16.0
 tqdm==4.61.2
 uritemplate==3.0.1
 urllib3==1.26.5
+twitchAPI==4.2.0


### PR DESCRIPTION
Work in progress

The Twitch process will be pretty close to the code for updating Twitter.

Recall that for Twitter, X username (P2002) has a Twitter numeric user ID (P6552) qualifier.

For Twitch we have Twitch channel ID (P5797) (but this name isn't correct, it's really a Twitch channel name which sometimes change, but whatever). We need to add the channel ID using the Twitch numeric channel ID (P12229) qualifier. We then need to backfill these. When we've done so, we can use these IDs without needing to request them again from the Twitch API.

---
To generate API credentials:
1. First go to https://www.twitch.tv/settings/profile and login with a Twitch account.
2. Go to Security and Privacy and set up two factor authentication. Twitch requires you to supply a phone number for this; after doing so, you can use it for SMS 2FA or set up Authenticator.
3. Next, go to https://dev.twitch.tv/console. You will be prompted to authorize your account. Then, click Applications -> Register Your Application. For `Name` - enter whatever you want, but FYI it seems to not like generic names like "test". `OAuth Redirect URLs` - http://localhost. `Category` - shouldn't matter. `Client Type` - Confidential.
4. On the next screen click Manage. Copy the Client ID. Then, click New Secret. Then click "I am not a robot" (IMPORTANT). Then click Save. Make sure the Save button turns to a success button.
5. Save these two values to your Credentials file with the key names `twitch-client-id` and `twitch-secret`.